### PR TITLE
fix(ci): restore cosign auth and make the SBOM non-blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,21 +79,6 @@ jobs:
           just build
           echo "image_id=$(cat /tmp/image.id)" >> "$GITHUB_OUTPUT"
 
-      # Generate the SBOM from the locally-built image. Scanning a saved
-      # oci-archive avoids re-pulling the multi-hundred-layer image from the
-      # registry, which previously stalled the runner until it was cancelled.
-      - name: Install syft
-        uses: anchore/sbom-action/download-syft@43a17d6e7add2b5535efe4dcae9952337c479a93 # v0.20.11
-
-      - name: Generate SBOM
-        env:
-          IMAGE_ID: ${{ steps.build.outputs.image_id }}
-        run: |
-          set -xeuo pipefail
-          podman save --format oci-archive -o /tmp/image.oci "$IMAGE_ID"
-          syft "oci-archive:/tmp/image.oci" --output spdx-json=sbom.spdx.json
-          jq . sbom.spdx.json > /dev/null
-
       - name: Login to Quay.io
         if: env.PUSH_IMAGE == 'true'
         env:
@@ -133,8 +118,32 @@ jobs:
             --yes \
             "$IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST"
 
-      - name: Attach SBOM to image
+      # The image is now pushed and signed. Everything below is best-effort SBOM
+      # generation. It runs after the image is published and is marked
+      # continue-on-error so a syft or cosign-attest failure never blocks an
+      # image update. The SBOM is built from the locally-built image (a saved
+      # oci-archive), which avoids re-pulling the many-layer image from the
+      # registry.
+      - name: Install syft
         if: env.PUSH_IMAGE == 'true'
+        continue-on-error: true
+        uses: anchore/sbom-action/download-syft@43a17d6e7add2b5535efe4dcae9952337c479a93 # v0.20.11
+
+      - name: Generate SBOM
+        if: env.PUSH_IMAGE == 'true'
+        id: sbom
+        continue-on-error: true
+        env:
+          IMAGE_ID: ${{ steps.build.outputs.image_id }}
+        run: |
+          set -xeuo pipefail
+          podman save --format oci-archive -o /tmp/image.oci "$IMAGE_ID"
+          syft "oci-archive:/tmp/image.oci" --output spdx-json=sbom.spdx.json
+          jq . sbom.spdx.json > /dev/null
+
+      - name: Attach SBOM to image
+        if: env.PUSH_IMAGE == 'true' && steps.sbom.outcome == 'success'
+        continue-on-error: true
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,10 @@ jobs:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         run: |
+          # podman login authenticates the push; docker login writes
+          # ~/.docker/config.json, which cosign reads for sign and attest.
           podman login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
+          docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
 
       - name: Tag and push image
         if: env.PUSH_IMAGE == 'true'


### PR DESCRIPTION
## Why

Two CI problems:

1. `cosign sign` fails on `main` with `UNAUTHORIZED` when it pushes the
   signature to quay. The login step ran only `podman login`, but cosign reads
   `~/.docker/config.json`. The push succeeded, then the sign step failed. This
   currently breaks the `main` build.
2. The SBOM ran before the push and sign steps, so a `syft` or attest failure
   could block an image update.

## What

- Add `docker login` next to `podman login` so cosign has the credentials it
  needs to push signatures and attestations.
- Move the tag, push, and `cosign sign` steps ahead of the SBOM steps. The
  image is published and signed first.
- Mark the SBOM steps (`Install syft`, `Generate SBOM`, `Attach SBOM`)
  `continue-on-error: true`. A failure there does not fail the job.
- Gate the SBOM steps on `PUSH_IMAGE == 'true'` and skip the attest step when
  the SBOM did not build.
- Keep the SBOM source local (a saved oci-archive). It does not re-pull the
  many-layer image from the registry.

New step order: build → login → push → sign → (best-effort) syft → SBOM → attest.

## How to test

1. Open this pull request. Confirm the SBOM, push, and sign steps skip, because
   `PUSH_IMAGE` is false for a pull request.
2. Merge to `main`. Confirm the image pushes, then `cosign sign` succeeds.
3. Confirm the workflow stays green even if the SBOM steps fail.

## Risks and follow-ups

- Low risk. The change reorders steps, restores a login, and relaxes SBOM
  failure handling.
- This pull request fixes the currently broken `main` build.

## Links

- Follows the pipeline work in #13.
