### PR TITLE
fix(ci): skip the rekor tlog when signing and attesting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,14 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
+          # Key-based signing. Skip the public rekor transparency log so the job
+          # does not depend on an external service that can time out and block
+          # the sign step. Verify with `cosign verify --key <pub>
+          # --insecure-ignore-tlog=true`.
           cosign sign --key env://COSIGN_PRIVATE_KEY \
             --new-bundle-format=false \
             --use-signing-config=false \
+            --tlog-upload=false \
             --yes \
             "$IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST"
 
@@ -155,5 +160,6 @@ jobs:
           cosign attest --key env://COSIGN_PRIVATE_KEY \
             --type spdxjson \
             --predicate sbom.spdx.json \
+            --tlog-upload=false \
             --yes \
             "$IMAGE_REGISTRY/$IMAGE_NAME@$DIGEST"


### PR DESCRIPTION
## Why

`cosign sign` and `cosign attest` uploaded to the public sigstore transparency
log (rekor) by default. A rekor timeout failed the `Attach SBOM` step:

```
Post "https://rekor.sigstore.dev/api/v1/log/entries": giving up after 2 attempt(s)
```

The attest step is `continue-on-error`, so it did not block. But the **sign**
step is not, and it uses the same rekor call. A rekor outage during sign would
fail the job and block an image update.

## What

- Add `--tlog-upload=false` to `cosign sign` and `cosign attest`.
- The image uses key-based signing, so the public transparency log is optional.
  Removing it drops an external dependency that can time out.

## How to test

1. Merge to `main`. Confirm the sign and attest steps pass without a rekor call.
2. Verify the image:
   `cosign verify --key <public-key> --insecure-ignore-tlog=true quay.io/rsturla-dev/workbench:latest`.

## Risks and follow-ups

- Verifiers must pass `--insecure-ignore-tlog=true` because there is no tlog
  entry. This is expected for key-based signing without a transparency log.
- Follow-up: document the verify command for image consumers.

## Links

- Follows the SBOM and signing work in #15.
